### PR TITLE
fix: edit PKGBUILD to conform to Arch packaging guidelines

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,9 @@
 # Maintainer: Nomadcxx <noovie@gmail.com>
+# Contributor: Luis Martinez <luis dot martinez at disroot dot org>
+
 pkgname=moonbit
 pkgver=1.2.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A modern system cleaner built in Go with a TUI and CLI"
 arch=('x86_64' 'aarch64')
 url="https://github.com/Nomadcxx/moonbit"
@@ -15,13 +17,19 @@ source=("${pkgname}-${pkgver}.tar.gz::https://github.com/Nomadcxx/${pkgname}/arc
 sha256sums=('f1c678581319e96f49c40d0e0ca5ea3710a2598d2e21ec1e1425f25fb469655f')
 install=${pkgname}.install
 
+prepare() {
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    export GOPATH="$srcdir"
+    go mod download -modcacherw
+}
+
 build() {
     cd "${srcdir}/${pkgname}-${pkgver}"
     export CGO_CPPFLAGS="${CPPFLAGS}"
     export CGO_CFLAGS="${CFLAGS}"
     export CGO_CXXFLAGS="${CXXFLAGS}"
     export CGO_LDFLAGS="${LDFLAGS}"
-    export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+    export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
 
     go build -buildvcs=false -o moonbit cmd/main.go
 }
@@ -30,13 +38,13 @@ package() {
     cd "${srcdir}/${pkgname}-${pkgver}"
 
     # Install binary
-    install -Dm755 moonbit "${pkgdir}/usr/local/bin/moonbit"
+    install -Dm755 moonbit "${pkgdir}/usr/bin/moonbit"
 
     # Install systemd service and timer files
-    install -Dm644 systemd/moonbit-scan.service "${pkgdir}/etc/systemd/system/moonbit-scan.service"
-    install -Dm644 systemd/moonbit-scan.timer "${pkgdir}/etc/systemd/system/moonbit-scan.timer"
-    install -Dm644 systemd/moonbit-clean.service "${pkgdir}/etc/systemd/system/moonbit-clean.service"
-    install -Dm644 systemd/moonbit-clean.timer "${pkgdir}/etc/systemd/system/moonbit-clean.timer"
+    install -Dm644 systemd/moonbit-scan.service "${pkgdir}/usr/lib/systemd/system/moonbit-scan.service"
+    install -Dm644 systemd/moonbit-scan.timer "${pkgdir}/usr/lib/systemd/system/moonbit-scan.timer"
+    install -Dm644 systemd/moonbit-clean.service "${pkgdir}/usr/lib/systemd/system/moonbit-clean.service"
+    install -Dm644 systemd/moonbit-clean.timer "${pkgdir}/usr/lib/systemd/system/moonbit-clean.timer"
 
     # Install README
     install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"


### PR DESCRIPTION
[Arch packaging guidelines](https://wiki.archlinux.org/title/Arch_package_guidelines) forbid installing binaries to `/usr/local/`. This patch fixes that, along with a few other details.

* Added a `prepare()` function to download all dependencies before building. This ensures that the source package can build entirely offline.
* Moved the systemd files from `/etc/systemd/` to `/usr/lib/systemd`. Arch's `namcap` tool advises to install such files under `/usr/lib/systemd`. `/etc/systemd` is for the user to make system-wide configurations.

Please note the `pkgrel` bump -- this should reset back to 1 with the next release. Hope you find this useful!

Luis